### PR TITLE
feat/theme-toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,28 +1,165 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
+@theme {
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+  --color-neutral-50: #fafafa;
+  --color-neutral-100: #f5f5f5;
+  --color-neutral-200: #e5e5e5;
+  --color-neutral-800: #262626;
+  --color-neutral-900: #171717;
+  --color-neutral-950: #0a0a0a;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+:root {
+  --background: #ffffff;
+  --foreground: #000000;
+}
+
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+}
+
+[data-theme="dark"] {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+}
+
+/* Light mode overrides to ensure proper colors */
+.light .bg-neutral-50,
+:root .bg-neutral-50 { 
+  background-color: #ffffff !important; 
+}
+
+.light .bg-white,
+:root .bg-white { 
+  background-color: #ffffff !important; 
+}
+
+.light .bg-neutral-100,
+:root .bg-neutral-100 { 
+  background-color: #f5f5f5 !important; 
+}
+
+.light .text-neutral-800,
+:root .text-neutral-800 { 
+  color: #000000 !important; 
+}
+
+.light .text-neutral-200,
+:root .text-neutral-200 { 
+  color: #000000 !important; 
+}
+
+.light .text-neutral-600,
+:root .text-neutral-600 { 
+  color: #404040 !important; 
+}
+
+.light .text-neutral-400,
+:root .text-neutral-400 { 
+  color: #525252 !important; 
+}
+
+.light .text-neutral-500,
+:root .text-neutral-500 { 
+  color: #737373 !important; 
+}
+
+.light .text-neutral-700,
+:root .text-neutral-700 { 
+  color: #262626 !important; 
+}
+
+.light .text-neutral-300,
+:root .text-neutral-300 { 
+  color: #171717 !important; 
+}
+
+.light .text-neutral-900,
+:root .text-neutral-900 { 
+  color: #000000 !important; 
+}
+
+.light .text-neutral-100,
+:root .text-neutral-100 { 
+  color: #0a0a0a !important; 
+}
+
+.light .border-neutral-200,
+:root .border-neutral-200 { 
+  border-color: #e5e5e5 !important; 
+}
+
+.light .border-neutral-300,
+:root .border-neutral-300 { 
+  border-color: #d4d4d4 !important; 
+}
+
+/* Ensure all cards/containers have proper light mode styling */
+:not(.dark) .bg-white { 
+  background-color: #ffffff !important; 
+}
+
+:not(.dark) .bg-neutral-50 { 
+  background-color: #fafafa !important; 
+}
+
+:not(.dark) .bg-neutral-100 { 
+  background-color: #f5f5f5 !important; 
+}
+
+:not(.dark) .bg-neutral-900 { 
+  background-color: #ffffff !important; 
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+/* Force dark mode styles - comprehensive overrides */
+.dark .bg-neutral-50 { background-color: #0a0a0a !important; }
+.dark .bg-white { background-color: #171717 !important; }
+.dark .bg-neutral-100 { background-color: #262626 !important; }
+.dark .bg-neutral-900 { background-color: #171717 !important; }
+
+.dark .text-neutral-800 { color: #e5e5e5 !important; }
+.dark .text-neutral-200 { color: #e5e5e5 !important; }
+.dark .text-neutral-600 { color: #a3a3a3 !important; }
+.dark .text-neutral-400 { color: #a3a3a3 !important; }
+.dark .text-neutral-500 { color: #737373 !important; }
+.dark .text-neutral-700 { color: #d4d4d4 !important; }
+.dark .text-neutral-300 { color: #d4d4d4 !important; }
+.dark .text-neutral-900 { color: #f5f5f5 !important; }
+.dark .text-neutral-100 { color: #f5f5f5 !important; }
+
+.dark .border-neutral-200 { border-color: #404040 !important; }
+.dark .border-neutral-300 { border-color: #525252 !important; }
+.dark .border-neutral-700 { border-color: #525252 !important; }
+.dark .border-neutral-800 { border-color: #404040 !important; }
+
+/* Force specific component overrides */
+.dark [class*="bg-white"] { background-color: #171717 !important; }
+.dark [class*="bg-neutral-50"] { background-color: #0a0a0a !important; }
+.dark [class*="bg-neutral-100"] { background-color: #262626 !important; }
+.dark [class*="bg-neutral-900"] { background-color: #171717 !important; }
+
+/* Override any min-h-screen background */
+.dark .min-h-screen { background-color: #0a0a0a !important; }
+
+/* Force all containers and divs to respect dark mode */
+.dark div[class*="bg-"] { 
+  background-color: #171717 !important; 
+}
+.dark div[class*="bg-neutral-50"] { 
+  background-color: #0a0a0a !important; 
+}
+.dark div[class*="bg-white"] { 
+  background-color: #171717 !important; 
 }
 
 input[type='color']::-webkit-color-swatch-wrapper {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { ThemeProvider } from "@/contexts/ThemeContext";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -30,11 +31,42 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  const savedTheme = localStorage.getItem('theme') || 'system';
+                  const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                  
+                  let resolvedTheme = 'light';
+                  if (savedTheme === 'dark') {
+                    resolvedTheme = 'dark';
+                  } else if (savedTheme === 'system' && systemPrefersDark) {
+                    resolvedTheme = 'dark';
+                  }
+                  
+                  if (resolvedTheme === 'dark') {
+                    document.documentElement.classList.add('dark');
+                    document.documentElement.style.colorScheme = 'dark';
+                  } else {
+                    document.documentElement.classList.remove('dark');
+                    document.documentElement.style.colorScheme = 'light';
+                  }
+                } catch (e) {
+                  console.error('Theme initialization error:', e);
+                }
+              })();
+            `,
+          }}
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <ThemeProvider>{children}</ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState, useEffect } from "react";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 export default function ABImageGenerator() {
   const [leftImage, setLeftImage] = useState<string | null>(null);
@@ -9,7 +10,12 @@ export default function ABImageGenerator() {
   const [labelFont, setLabelFont] = useState("Inter");
   const [borderRadius, setBorderRadius] = useState(24);
   const [generated, setGenerated] = useState(false);
+  const [mounted, setMounted] = useState(false);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const handleImageFile = (file: File, side: "left" | "right") => {
     const url = URL.createObjectURL(file);
@@ -174,13 +180,39 @@ export default function ABImageGenerator() {
     "Monaco",
   ];
 
+  // Don't render the ThemeToggle until mounted to prevent hydration issues
+  if (!mounted) {
+    return (
+      <div className="min-h-screen bg-neutral-50 dark:bg-neutral-950">
+        <div className="container mx-auto px-4 py-8">
+          <header className="flex items-center justify-between mb-10">
+            <div className="flex-1 text-center">
+              <h1 className="text-3xl font-bold text-neutral-800 dark:text-neutral-200">
+                A/B Test Image Generator
+              </h1>
+            </div>
+            <div className="flex items-center gap-4">
+              <div className="w-24 h-9 rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900" />
+            </div>
+          </header>
+          {/* Rest of the content */}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-neutral-50 dark:bg-neutral-950">
       <div className="container mx-auto px-4 py-8">
-        <header className="text-center mb-10">
-          <h1 className="text-3xl font-bold text-neutral-800 dark:text-neutral-200">
-            A/B Test Image Generator
-          </h1>
+        <header className="flex items-center justify-between mb-10">
+          <div className="flex-1 text-center">
+            <h1 className="text-3xl font-bold text-neutral-800 dark:text-neutral-200">
+              A/B Test Image Generator
+            </h1>
+          </div>
+          <div className="flex items-center gap-4">
+            <ThemeToggle />
+          </div>
         </header>
 
         <main className="flex flex-col gap-8">
@@ -343,7 +375,7 @@ export default function ABImageGenerator() {
               <button
                 onClick={generateImage}
                 disabled={!leftImage || !rightImage}
-                className="w-full bg-blue-600 text-white h-12 px-4 rounded-lg font-semibold hover:bg-blue-700 transition-all duration-200 ease-in-out disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-neutral-300 dark:disabled:bg-neutral-700 flex items-center justify-center gap-2 shadow-sm hover:shadow-md transform hover:-translate-y-0.5"
+                className="w-full bg-blue-600 text-white h-12 px-4 rounded-lg font-semibold hover:bg-blue-700 transition-all duration-200 ease-in-out disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-neutral-300 dark:disabled:bg-black flex items-center justify-center gap-2 shadow-sm hover:shadow-md transform hover:-translate-y-0.5"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -364,7 +396,7 @@ export default function ABImageGenerator() {
               <button
                 onClick={downloadImage}
                 disabled={!generated}
-                className="w-full bg-neutral-200 dark:bg-neutral-800 text-neutral-800 dark:text-neutral-200 h-12 px-4 rounded-lg font-semibold hover:bg-neutral-300 dark:hover:bg-neutral-700 transition-all duration-200 ease-in-out disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 shadow-sm hover:shadow-md transform hover:-translate-y-0.5"
+                className="w-full bg-neutral-200 dark:bg-black text-white dark:text-neutral-200 h-12 px-4 rounded-lg font-semibold hover:bg-neutral-300 dark:hover:bg-neutral-700 transition-all duration-200 ease-in-out disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 shadow-sm hover:shadow-md transform hover:-translate-y-0.5"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -414,7 +446,7 @@ export default function ABImageGenerator() {
                             stroke="currentColor"
                             viewBox="0 0 24 24"
                           >
-                            <path d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                            <path d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2 2v12a2 2 0 002 2z" />
                           </svg>
                         </div>
                         <p className="text-neutral-600 dark:text-neutral-400 text-lg font-medium mb-2">

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useTheme } from '@/contexts/ThemeContext';
+import { useEffect, useState } from 'react';
+
+export function ThemeToggle() {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-2 rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 w-24 h-9" />
+    );
+  }
+
+  const toggleTheme = () => {
+    if (theme === 'light') {
+      setTheme('dark');
+    } else if (theme === 'dark') {
+      setTheme('system');
+    } else {
+      setTheme('light');
+    }
+  };
+
+  const getIcon = () => {
+    if (theme === 'system') {
+      return (
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+          />
+        </svg>
+      );
+    }
+    
+    if (resolvedTheme === 'dark') {
+      return (
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+          />
+        </svg>
+      );
+    }
+
+    return (
+      <svg
+        className="w-5 h-5"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+        />
+      </svg>
+    );
+  };
+
+  const getLabel = () => {
+    if (theme === 'system') {
+      return `Auto (${resolvedTheme})`;
+    }
+    return theme === 'light' ? 'Light' : 'Dark';
+  };
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="flex items-center gap-2 px-3 py-2 rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-800 transition-colors"
+      title={`Current theme: ${getLabel()}. Click to cycle through light → dark → auto`}
+    >
+      {getIcon()}
+      <span className="hidden md:block text-sm font-medium">{getLabel()}</span>
+    </button>
+  );
+}

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark' | 'system';
+
+interface ThemeContextType {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  resolvedTheme: 'light' | 'dark';
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+function applyTheme(theme: 'light' | 'dark') {
+  const root = document.documentElement;
+  if (theme === 'dark') {
+    root.classList.add('dark');
+    root.style.colorScheme = 'dark';
+    root.setAttribute('data-theme', 'dark');
+  } else {
+    root.classList.remove('dark');
+    root.style.colorScheme = 'light';
+    root.setAttribute('data-theme', 'light');
+  }
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('system');
+  const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('light');
+  const [mounted, setMounted] = useState(false);
+
+  // Initialize theme on mount
+  useEffect(() => {
+    setMounted(true);
+    const savedTheme = localStorage.getItem('theme') as Theme | null;
+    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    
+    let initialTheme: Theme = 'system';
+    let initialResolvedTheme: 'light' | 'dark' = systemPrefersDark ? 'dark' : 'light';
+    
+    if (savedTheme && ['light', 'dark', 'system'].includes(savedTheme)) {
+      initialTheme = savedTheme;
+      if (savedTheme === 'system') {
+        initialResolvedTheme = systemPrefersDark ? 'dark' : 'light';
+      } else {
+        initialResolvedTheme = savedTheme;
+      }
+    }
+    
+    setTheme(initialTheme);
+    setResolvedTheme(initialResolvedTheme);
+    applyTheme(initialResolvedTheme);
+  }, []);
+
+  // Handle theme changes
+  useEffect(() => {
+    if (!mounted) return;
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    
+    const updateResolvedTheme = () => {
+      let newResolvedTheme: 'light' | 'dark';
+      
+      if (theme === 'system') {
+        newResolvedTheme = mediaQuery.matches ? 'dark' : 'light';
+      } else {
+        newResolvedTheme = theme;
+      }
+      
+      setResolvedTheme(newResolvedTheme);
+      applyTheme(newResolvedTheme);
+      localStorage.setItem('theme', theme);
+    };
+
+    const handleSystemChange = () => {
+      if (theme === 'system') {
+        updateResolvedTheme();
+      }
+    };
+
+    updateResolvedTheme();
+    mediaQuery.addEventListener('change', handleSystemChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleSystemChange);
+    };
+  }, [theme, mounted]);
+
+  if (!mounted) {
+    return <>{children}</>;
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, resolvedTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,8 @@
+import { Config } from 'tailwindcss'
+
+export default {
+  darkMode: 'class',
+  content: [
+    './src/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+} satisfies Config


### PR DESCRIPTION
### Title: feat: Add light/dark mode toggle and system preference

### Description

This PR introduces a theme-switching functionality to enhance user experience. It adds a toggle for manually switching between light and dark modes and automatically sets the initial theme based on the user's operating system (OS) preference.

The user's manual choice is saved in local storage to persist across sessions, overriding the system setting.

Closes #3

### Changes Made

- **Theme Toggle Component:** A new UI component has been added to the navigation bar/settings page that allows users to switch between light and dark themes.
- **System Preference Detection:** Implemented logic using the `prefers-color-scheme` media query to detect the user's OS theme setting on initial load.
- **Theme Persistence:** The user's selected theme is now stored in `localStorage`, ensuring their choice is remembered on subsequent visits.
- **Styling:** Added CSS variables and updated styles across the application to support both themes.

### How to Test

1.  **System Preference Check:**
    - Clear your browser's local storage for this site.
    - Set your OS to **Light Mode**. Open the app and verify it loads in light mode.
    - Set your OS to **Dark Mode**. Refresh the page and verify it loads in dark mode.

2.  **Manual Toggle Functionality:**
    - Click the theme toggle button. The theme should switch instantly.
    - Toggle it back and forth to ensure both themes apply correctly.

3.  **Persistence Check:**
    - Manually select a theme (e.g., Light Mode).
    - Refresh the page. The application should remain in Light Mode.
    - Close and reopen the browser tab. The selected theme should still be active.

### Screenshots

**Light Mode:**
<img width="1896" height="860" alt="image" src="https://github.com/user-attachments/assets/2da57938-6e93-4b4c-a9ce-125b2f3bdaf1" />

**Dark Mode: (Auto-detect)**
<img width="1897" height="855" alt="image" src="https://github.com/user-attachments/assets/d5eefb26-a6c1-4e59-b649-2e7883bf2650" />